### PR TITLE
Submit form through ajax and update output area without reloading the page

### DIFF
--- a/index.php
+++ b/index.php
@@ -464,14 +464,15 @@ else {
                         // Update the output area with the response
                         var $output = $('.file-output');
                         var filteredResponse = $(response).find('.file-output').html();
-                        $output.html(filteredResponse);
+                        var decodedResponse = $('<textarea/>').html(filteredResponse).text();
+                        $output.html(decodedResponse);
 
                         // Reinitialize CodeMirror for the updated output
                         CodeMirror(function(elt) {
                             $output.replaceWith(elt);
                             $(elt).addClass('file-output');
                         }, {
-                            value: filteredResponse,
+                            value: decodedResponse,
                             readOnly: true,
                             mode: "text/<?php echo stristr(array_keys($files)[0], '.css') ? 'css' : 'html'; ?>",
                             lineNumbers: true,

--- a/index.php
+++ b/index.php
@@ -252,7 +252,7 @@ else {
     </head>
     <body>
 
-        <form method="POST">
+        <form id="twig-form" method="POST">
 
             <header>
                 <input type="submit" class="submit-btn" value="Render">
@@ -448,6 +448,39 @@ else {
                 mode: "text/<?php echo stristr(array_keys($files)[0], '.css') ? 'css' : 'html'; ?>",
                 lineNumbers: true,
                 viewportMargin: Infinity
+            });
+
+            // Add event handler for form submission
+            $('#twig-form').submit(function(event) {
+                event.preventDefault(); // Prevent default form submission
+
+                var formData = $(this).serialize(); // Serialize form data
+
+                $.ajax({
+                    type: 'POST',
+                    url: '', // Current page URL
+                    data: formData,
+                    success: function(response) {
+                        // Update the output area with the response
+                        var $output = $('.file-output');
+                        $output.html(response);
+
+                        // Reinitialize CodeMirror for the updated output
+                        CodeMirror(function(elt) {
+                            $output.replaceWith(elt);
+                            $(elt).addClass('file-output');
+                        }, {
+                            value: response,
+                            readOnly: true,
+                            mode: "text/<?php echo stristr(array_keys($files)[0], '.css') ? 'css' : 'html'; ?>",
+                            lineNumbers: true,
+                            viewportMargin: Infinity
+                        });
+                    },
+                    error: function() {
+                        alert('An error occurred while processing the request.');
+                    }
+                });
             });
 
         });

--- a/index.php
+++ b/index.php
@@ -463,14 +463,15 @@ else {
                     success: function(response) {
                         // Update the output area with the response
                         var $output = $('.file-output');
-                        $output.html(response);
+                        var filteredResponse = $(response).find('.file-output').html();
+                        $output.html(filteredResponse);
 
                         // Reinitialize CodeMirror for the updated output
                         CodeMirror(function(elt) {
                             $output.replaceWith(elt);
                             $(elt).addClass('file-output');
                         }, {
-                            value: response,
+                            value: filteredResponse,
                             readOnly: true,
                             mode: "text/<?php echo stristr(array_keys($files)[0], '.css') ? 'css' : 'html'; ?>",
                             lineNumbers: true,


### PR DESCRIPTION
Add AJAX form submission for the Render button to update the output area without reloading the page.

* Add an ID to the form element for easier targeting with JavaScript.
* Add a JavaScript event handler for the form submission to handle the click event and submit the form through AJAX.
* Prevent the default form submission behavior to avoid reloading the page.
* Serialize the form data and send it via AJAX to the server.
* Update the output area with the response from the server after the form submission.
* Reinitialize CodeMirror for the updated output to ensure syntax highlighting.

